### PR TITLE
Frontport existing and include new testcases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@
 name: CI
 on: [push, pull_request, workflow_dispatch]
 jobs:
-  ci:
+  basic:
     strategy:
       fail-fast: false
       matrix:
@@ -10,32 +10,26 @@ jobs:
         python-version: ["3.8", "3.9", "3.10"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Set up a virtual environment for Python ${{ matrix.python-version }}
-        run: |
-             python -m pip install --upgrade virtualenv
-             virtualenv venv
-             source venv/bin/activate
-             which python
       - name: Install the base dependencies
         run: |
-             source venv/bin/activate
              python -m pip install --upgrade poetry
+
       - name: Check the correctness of the project config
         run: |
-             source venv/bin/activate
              poetry check
-      - name: Install the package
+
+      - name: Install the project
         run: |
-             source venv/bin/activate
+             poetry config virtualenvs.create false
              poetry install
+
       - name: Check the quality of the code
         run: |
-             source venv/bin/activate
-             pytest
+             tox

--- a/mdapi/__init__.py
+++ b/mdapi/__init__.py
@@ -29,48 +29,34 @@ from logging.config import dictConfig
 
 from requests.packages.urllib3 import disable_warnings
 
-from mdapi.confdata.servlogr import logrobjc  # noqa
-from mdapi.confdata.standard import (  # noqa
-    APPSERVE,
-    CRON_SLEEP,
-    DB_FOLDER,
-    DL_SERVER,
-    DL_VERIFY,
-    KOJI_REPO,
-    LOGGING,
-    PKGDB2_URL,
-    PKGDB2_VERIFY,
-    PUBLISH_CHANGES,
-    repomd_xml_namespace,
-)
+from mdapi.confdata import servlogr, standard
 
 __version__ = metadata.version("mdapi")
 
 
 def compile_configuration(confobjc):
-    global DB_FOLDER, LOGGING, KOJI_REPO, PKGDB2_URL, DL_SERVER, PKGDB2_VERIFY, DL_VERIFY
-    global PUBLISH_CHANGES, CRON_SLEEP, repomd_xml_namespace, APPSERVE
-    DB_FOLDER = confobjc.get("DB_FOLDER", DB_FOLDER)
-    PKGDB2_URL = confobjc.get("PKGDB2_URL", PKGDB2_URL)
-    KOJI_REPO = confobjc.get("KOJI_REPO", KOJI_REPO)
-    DL_SERVER = confobjc.get("DL_SERVER", DL_SERVER)
-    PKGDB2_VERIFY = confobjc.get("PKGDB2_VERIFY", PKGDB2_VERIFY)
-    DL_VERIFY = confobjc.get("DL_VERIFY", DL_VERIFY)
-    PUBLISH_CHANGES = confobjc.get("PUBLISH_CHANGES", PUBLISH_CHANGES)
-    CRON_SLEEP = confobjc.get("CRON_SLEEP", CRON_SLEEP)
-    LOGGING = confobjc.get("LOGGING", LOGGING)
-    repomd_xml_namespace = confobjc.get("repomd_xml_namespace", repomd_xml_namespace)
-    APPSERVE = confobjc.get("APPSERVE", APPSERVE)
+    standard.DB_FOLDER = confobjc.get("DB_FOLDER", standard.DB_FOLDER)
+    standard.PKGDB2_URL = confobjc.get("PKGDB2_URL", standard.PKGDB2_URL)
+    standard.KOJI_REPO = confobjc.get("KOJI_REPO", standard.KOJI_REPO)
+    standard.DL_SERVER = confobjc.get("DL_SERVER", standard.DL_SERVER)
+    standard.PKGDB2_VERIFY = confobjc.get("PKGDB2_VERIFY", standard.PKGDB2_VERIFY)
+    standard.DL_VERIFY = confobjc.get("DL_VERIFY", standard.DL_VERIFY)
+    standard.PUBLISH_CHANGES = confobjc.get("PUBLISH_CHANGES", standard.PUBLISH_CHANGES)
+    standard.CRON_SLEEP = confobjc.get("CRON_SLEEP", standard.CRON_SLEEP)
+    standard.LOGGING = confobjc.get("LOGGING", standard.LOGGING)
+    standard.repomd_xml_namespace = confobjc.get(
+        "repomd_xml_namespace", standard.repomd_xml_namespace
+    )
+    standard.APPSERVE = confobjc.get("APPSERVE", standard.APPSERVE)
 
-    if not os.path.exists(DB_FOLDER):
+    if not os.path.exists(standard.DB_FOLDER):
         # Cannot pull/push data from/into directory that does not exist
         print("Database directory not found")
         sys.exit(1)
 
-    if not DL_VERIFY or not PKGDB2_VERIFY:
+    if not standard.DL_VERIFY or not standard.PKGDB2_VERIFY:
         # Suppress urllib3's warnings about insecure requests
         disable_warnings()
 
-    dictConfig(LOGGING)
-    global logrobjc
-    logrobjc = getLogger(__name__)
+    dictConfig(standard.LOGGING)
+    servlogr.logrobjc = getLogger(__name__)

--- a/mdapi/database/base.py
+++ b/mdapi/database/base.py
@@ -23,12 +23,12 @@ of Red Hat, Inc.
 
 import sqlite3
 
-from mdapi.confdata.servlogr import logrobjc
+from mdapi.confdata import servlogr
 from mdapi.database.sqlq import DEFAULT_QUERY, INDEX_DATABASE, OBTAIN_TABLE_NAMES, queries
 
 
 def index_database(name, tempdtbs):
-    logrobjc.info("[%s] Indexing database %s" % (name, tempdtbs))
+    servlogr.logrobjc.info("[%s] Indexing database %s" % (name, tempdtbs))
     if tempdtbs.endswith("primary.sqlite"):
         # TODO: Try the "with sqlite3.connect(tempdtbs) as connobjc" statement here
         connobjc = sqlite3.connect(tempdtbs)
@@ -85,11 +85,11 @@ class compare_databases:
                 if rowe[0] in cacheobj:
                     yield (cacheobj[rowe[0]], *rowe[1:])
                 else:
-                    logrobjc.warning(
+                    servlogr.logrobjc.warning(
                         "[%s] % does not appear in the %s cache for %s"
                         % (self.name, rowe[0], tableobj, location)
                     )
-                    logrobjc.warning("[%s] Dropping from comparison")
+                    servlogr.logrobjc.warning("[%s] Dropping from comparison")
             else:
                 yield rowe
         connobjc.close()
@@ -108,20 +108,22 @@ class compare_databases:
         return True
 
     def main(self):
-        logrobjc.info("[%s] Comparing %s against %s" % (self.name, self.dbsA, self.dbsB))
+        servlogr.logrobjc.info("[%s] Comparing %s against %s" % (self.name, self.dbsA, self.dbsB))
 
         tablistA = list(self.obtain_table_names(self.dbsA))
         tablistB = list(self.obtain_table_names(self.dbsB))
 
         if not tablistA and not tablistB:
-            logrobjc.error("Something is not right")
+            servlogr.logrobjc.error("Something is not right")
             raise RuntimeError("Something is not right")
 
         if not tablistB:
             # We have never downloaded this before...
             # so we have nothing to compare it against. Just return and say there
             # are "no differences".
-            logrobjc.warning("[%s] Database empty - %s cannot compare" % (self.name, self.dbsB))
+            servlogr.logrobjc.warning(
+                "[%s] Database empty - %s cannot compare" % (self.name, self.dbsB)
+            )
             return set()
 
         assert len(tablistA) == len(tablistB), "Cannot compare disparate databases"

--- a/mdapi/services/__init__.py
+++ b/mdapi/services/__init__.py
@@ -27,7 +27,7 @@ import re
 import aiosqlite
 from aiohttp.web import HTTPBadRequest, HTTPNotFound
 
-from mdapi.confdata.standard import DB_FOLDER
+from mdapi.confdata import standard
 from mdapi.database.sqlq import (
     GET_CHANGELOGS,
     GET_CO_PACKAGE,
@@ -53,9 +53,9 @@ async def _get_package(brch, name=None, actn=None, srcn=None):
 
     for repotype in ["updates-testing", "updates", "testing", None]:
         if repotype:
-            dtbsfile = "%s/mdapi-%s-%s-primary.sqlite" % (DB_FOLDER, brch, repotype)
+            dtbsfile = "%s/mdapi-%s-%s-primary.sqlite" % (standard.DB_FOLDER, brch, repotype)
         else:
-            dtbsfile = "%s/mdapi-%s-primary.sqlite" % (DB_FOLDER, brch)
+            dtbsfile = "%s/mdapi-%s-primary.sqlite" % (standard.DB_FOLDER, brch)
 
         if not os.path.exists(dtbsfile):
             wrongdbs = True
@@ -115,9 +115,9 @@ async def _expand_package_info(pkgs, brch, repotype):
     for pkgx in pkgs:
         otpt = pkgx.to_json()
         if repotype:
-            dtbsfile = "%s/mdapi-%s-%s-primary.sqlite" % (DB_FOLDER, brch, repotype)
+            dtbsfile = "%s/mdapi-%s-%s-primary.sqlite" % (standard.DB_FOLDER, brch, repotype)
         else:
-            dtbsfile = "%s/mdapi-%s-primary.sqlite" % (DB_FOLDER, brch)
+            dtbsfile = "%s/mdapi-%s-primary.sqlite" % (standard.DB_FOLDER, brch)
 
         async with aiosqlite.connect(dtbsfile) as dtbsobjc:
             """
@@ -168,9 +168,9 @@ async def _get_files(pkid, brch, repotype):
     Return the list of files for the given package in the specified branch.
     """
     if repotype:
-        dtbsfile = "%s/mdapi-%s-%s-filelists.sqlite" % (DB_FOLDER, brch, repotype)
+        dtbsfile = "%s/mdapi-%s-%s-filelists.sqlite" % (standard.DB_FOLDER, brch, repotype)
     else:
-        dtbsfile = "%s/mdapi-%s-filelists.sqlite" % (DB_FOLDER, brch)
+        dtbsfile = "%s/mdapi-%s-filelists.sqlite" % (standard.DB_FOLDER, brch)
 
     if not os.path.exists(dtbsfile):
         raise HTTPBadRequest()
@@ -194,9 +194,9 @@ async def _get_changelog(pkid, brch, repotype):
     Return the changelog for the given packages in the specified branch.
     """
     if repotype:
-        dtbsfile = "%s/mdapi-%s-%s-other.sqlite" % (DB_FOLDER, brch, repotype)
+        dtbsfile = "%s/mdapi-%s-%s-other.sqlite" % (standard.DB_FOLDER, brch, repotype)
     else:
-        dtbsfile = "%s/mdapi-%s-other.sqlite" % (DB_FOLDER, brch)
+        dtbsfile = "%s/mdapi-%s-other.sqlite" % (standard.DB_FOLDER, brch)
 
     if not os.path.exists(dtbsfile):
         raise HTTPBadRequest()

--- a/mdapi/services/appviews.py
+++ b/mdapi/services/appviews.py
@@ -25,20 +25,19 @@ import os.path
 
 from aiohttp.web import FileResponse, HTTPBadRequest, json_response
 
-from mdapi.confdata.servlogr import logrobjc
-from mdapi.confdata.standard import DB_FOLDER
+from mdapi.confdata import servlogr, standard
 from mdapi.services import _expand_package_info, _get_changelog, _get_files, _get_package
 
 homepage = os.path.join(os.path.dirname(os.path.abspath(__file__)), "homepage.html")
 
 
 async def index(rqst):
-    logrobjc.info("index %s" % rqst)
+    servlogr.logrobjc.info("index %s" % rqst)
     return FileResponse(homepage)
 
 
 async def get_pkg(rqst):
-    logrobjc.info("get_pkg %s" % rqst)
+    servlogr.logrobjc.info("get_pkg %s" % rqst)
     brch = rqst.match_info.get("brch")
     name = rqst.match_info.get("name")
     pckg, repotype = await _get_package(brch, name)
@@ -47,7 +46,7 @@ async def get_pkg(rqst):
 
 
 async def get_src_pkg(rqst):
-    logrobjc.info("get_src_pkg %s" % rqst)
+    servlogr.logrobjc.info("get_src_pkg %s" % rqst)
     brch = rqst.match_info.get("brch")
     name = rqst.match_info.get("name")
     pckg, repotype = await _get_package(brch, srcn=name)
@@ -59,12 +58,12 @@ async def list_branches(rqst):
     """
     Return the list of all branches currently supported by mdapi
     """
-    logrobjc.info("list_branches %s" % rqst)
+    servlogr.logrobjc.info("list_branches %s" % rqst)
     rslt = sorted(
         {
             # Remove the front part `mdapi-` and the end part `-<type>.sqlite` from the filenames
             filename.replace("mdapi-", "").rsplit("-", 2)[0].replace("-updates", "")
-            for filename in os.listdir(DB_FOLDER)
+            for filename in os.listdir(standard.DB_FOLDER)
             if filename.startswith("mdapi") and filename.endswith(".sqlite")
         }
     )
@@ -76,7 +75,7 @@ async def _process_dep(rqst, actn):
     Return the information about the packages having the specified action
     (as in provides, requires, obsoletes etc.)
     """
-    logrobjc.info("process_dep %s %s" % (actn, rqst))
+    servlogr.logrobjc.info("process_dep %s %s" % (actn, rqst))
     brch = rqst.match_info.get("brch")
     name = rqst.match_info.get("name")
 
@@ -122,7 +121,7 @@ async def get_supplements(rqst):
 
 
 async def get_pkg_files(rqst):
-    logrobjc.info("get_pkg_files %s" % rqst)
+    servlogr.logrobjc.info("get_pkg_files %s" % rqst)
     brch = rqst.match_info.get("brch")
     name = rqst.match_info.get("name")
     pckg, repotype = await _get_package(brch, name)
@@ -131,7 +130,7 @@ async def get_pkg_files(rqst):
 
 
 async def get_pkg_changelog(rqst):
-    logrobjc.info("get_pkg_changelog %s" % rqst)
+    servlogr.logrobjc.info("get_pkg_changelog %s" % rqst)
     brch = rqst.match_info.get("brch")
     name = rqst.match_info.get("name")
     pckg, repotype = await _get_package(brch, name)

--- a/mdapi/services/main.py
+++ b/mdapi/services/main.py
@@ -23,18 +23,7 @@ of Red Hat, Inc.
 
 from aiohttp.web import Application, HTTPException, get, middleware
 
-from mdapi.confdata.servlogr import logrobjc
-from mdapi.confdata.standard import (  # noqa
-    CRON_SLEEP,
-    DB_FOLDER,
-    DL_SERVER,
-    DL_VERIFY,
-    KOJI_REPO,
-    PKGDB2_URL,
-    PKGDB2_VERIFY,
-    PUBLISH_CHANGES,
-    repomd_xml_namespace,
-)
+from mdapi.confdata import servlogr
 from mdapi.services.appviews import (
     get_conflicts,
     get_enhances,
@@ -72,7 +61,7 @@ async def buildapp():
     This function creates a web application, configures the routes and returns the application
     object.
     """
-    applobjc = Application(middlewares=[add_cors_headers], logger=logrobjc)
+    applobjc = Application(middlewares=[add_cors_headers], logger=servlogr.logrobjc)
     applobjc.add_routes(
         [
             get("/", index),

--- a/poetry.lock
+++ b/poetry.lock
@@ -78,6 +78,21 @@ six = "*"
 visualize = ["graphviz (>0.5.1)", "Twisted (>=16.1.1)"]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.11.1"
+description = "Screen-scraping library"
+category = "dev"
+optional = false
+python-versions = ">=3.6.0"
+
+[package.dependencies]
+soupsieve = ">1.2"
+
+[package.extras]
+html5lib = ["html5lib"]
+lxml = ["lxml"]
+
+[[package]]
 name = "black"
 version = "22.8.0"
 description = "The uncompromising code formatter."
@@ -196,6 +211,14 @@ ssh = ["bcrypt (>=3.1.5)"]
 test = ["pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
 
 [[package]]
+name = "distlib"
+version = "0.3.6"
+description = "Distribution utilities"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "fedora-messaging"
 version = "3.1.0"
 description = "A set of tools for using Fedora's messaging infrastructure"
@@ -214,6 +237,18 @@ pytz = "*"
 service-identity = "*"
 toml = "*"
 Twisted = "*"
+
+[[package]]
+name = "filelock"
+version = "3.8.0"
+description = "A platform independent file lock."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo (>=2022.6.21)", "sphinx (>=5.1.1)", "sphinx-autodoc-typehints (>=1.19.1)"]
+testing = ["covdefaults (>=2.2)", "coverage (>=6.4.2)", "pytest (>=7.1.2)", "pytest-cov (>=3)", "pytest-timeout (>=2.1)"]
 
 [[package]]
 name = "flake8"
@@ -540,6 +575,36 @@ tomli = ">=1.0.0"
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
+name = "pytest-aiohttp"
+version = "1.0.4"
+description = "Pytest plugin for aiohttp support"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+aiohttp = ">=3.8.1"
+pytest = ">=6.1.0"
+pytest-asyncio = ">=0.17.2"
+
+[package.extras]
+testing = ["mypy (==0.931)", "coverage (==6.2)"]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.19.0"
+description = "Pytest support for asyncio"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+pytest = ">=6.1.0"
+
+[package.extras]
+testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)", "flaky (>=3.5.0)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
+
+[[package]]
 name = "pytest-black"
 version = "0.3.12"
 description = "A pytest plugin to enable format checking with black"
@@ -632,6 +697,14 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "soupsieve"
+version = "2.3.2.post1"
+description = "A modern CSS selector implementation for Beautiful Soup."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
@@ -646,6 +719,28 @@ description = "A lil' TOML parser"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
+
+[[package]]
+name = "tox"
+version = "3.26.0"
+description = "tox is a generic virtualenv management and test command line tool"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[package.dependencies]
+colorama = {version = ">=0.4.1", markers = "platform_system == \"Windows\""}
+filelock = ">=3.0.0"
+packaging = ">=14"
+pluggy = ">=0.12.0"
+py = ">=1.4.17"
+six = ">=1.14.0"
+tomli = {version = ">=2.0.1", markers = "python_version >= \"3.7\" and python_version < \"3.11\""}
+virtualenv = ">=16.0.0,<20.0.0 || >20.0.0,<20.0.1 || >20.0.1,<20.0.2 || >20.0.2,<20.0.3 || >20.0.3,<20.0.4 || >20.0.4,<20.0.5 || >20.0.5,<20.0.6 || >20.0.6,<20.0.7 || >20.0.7"
+
+[package.extras]
+docs = ["pygments-github-lexers (>=0.0.5)", "sphinx (>=2.0.0)", "sphinxcontrib-autoprogram (>=0.1.5)", "towncrier (>=18.5.0)"]
+testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-randomly (>=1.0.0)", "psutil (>=5.6.1)", "pathlib2 (>=2.3.3)"]
 
 [[package]]
 name = "twisted"
@@ -725,6 +820,23 @@ docs = ["Sphinx (>=4.1.2,<4.2.0)", "sphinxcontrib-asyncio (>=0.3.0,<0.4.0)", "sp
 test = ["aiohttp", "flake8 (>=3.9.2,<3.10.0)", "psutil", "pycodestyle (>=2.7.0,<2.8.0)", "pyOpenSSL (>=19.0.0,<19.1.0)", "mypy (>=0.800)"]
 
 [[package]]
+name = "virtualenv"
+version = "20.16.5"
+description = "Virtual Python Environment builder"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+distlib = ">=0.3.5,<1"
+filelock = ">=3.4.1,<4"
+platformdirs = ">=2.4,<3"
+
+[package.extras]
+docs = ["proselint (>=0.13)", "sphinx (>=5.1.1)", "sphinx-argparse (>=0.3.1)", "sphinx-rtd-theme (>=1)", "towncrier (>=21.9)"]
+testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=21.3)", "pytest (>=7.0.1)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.2)", "pytest-mock (>=3.6.1)", "pytest-randomly (>=3.10.3)", "pytest-timeout (>=2.1)"]
+
+[[package]]
 name = "wrapt"
 version = "1.14.1"
 description = "Module for decorators, wrappers and monkey patching."
@@ -772,7 +884,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "309800405b1ee6cad97e79d21eb785f6a8886f081bab7545b3b031693a3afd27"
+content-hash = "4d56b58bc08e59109bda36771b44d05b56c9528ec1cc1cee7afb15edc12c318a"
 
 [metadata.files]
 aiohttp = []
@@ -781,6 +893,7 @@ aiosqlite = []
 async-timeout = []
 attrs = []
 automat = []
+beautifulsoup4 = []
 black = []
 blinker = []
 certifi = []
@@ -791,7 +904,9 @@ colorama = []
 constantly = []
 crochet = []
 cryptography = []
+distlib = []
 fedora-messaging = []
+filelock = []
 flake8 = []
 frozenlist = []
 gunicorn = []
@@ -822,6 +937,8 @@ pyopenssl = []
 pyparsing = []
 pyrsistent = []
 pytest = []
+pytest-aiohttp = []
+pytest-asyncio = []
 pytest-black = []
 pytest-flake8 = []
 pytest-isort = []
@@ -829,13 +946,16 @@ pytz = []
 requests = []
 service-identity = []
 six = []
+soupsieve = []
 toml = []
 tomli = []
+tox = []
 twisted = []
 twisted-iocpsupport = []
 typing-extensions = []
 urllib3 = []
 uvloop = []
+virtualenv = []
 wrapt = []
 yarl = []
 zipp = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ uvloop = "^0.16.0"
 gunicorn = "^20.1.0"
 mdapi-messages = "^1.0.0"
 click = "^8.1.3"
-setuptools = "^65.3.0"
 
 [tool.poetry.dev-dependencies]
 black = "^22.8.0"
@@ -51,10 +50,14 @@ flake8 = "<4"
 pytest-black = "^0.3.12"
 pytest-flake8 = "^1.0.7"
 pytest-isort = "^3.0.0"
+beautifulsoup4 = "^4.11.1"
+tox = "^3.26.0"
+pytest-aiohttp = "^1.0.4"
 
 [tool.pytest.ini_options]
 addopts = "--black --isort --flake8"
 flake8-max-line-length = 100
+asyncio_mode = "auto"
 
 [tool.isort]
 line_length = 100

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,95 @@
+"""
+mdapi
+Copyright (C) 2015-2022 Red Hat, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Any Red Hat trademarks that are incorporated in the source
+code or documentation are not subject to the GNU General Public
+License and may only be used or replicated with the express permission
+of Red Hat, Inc.
+"""
+
+import os.path
+
+import requests
+from bs4 import BeautifulSoup
+from requests.exceptions import HTTPError
+
+from mdapi.confdata.servlogr import logrobjc
+from mdapi.database.main import extract_database, fetch_database
+
+"""
+Standard set of databases to run tests against
+"""
+
+LOCATION = "/var/tmp/mdapi-tests/"
+BRCHNAME = "rawhide"
+PROBEURL = {
+    "koji": "https://kojipkgs.fedoraproject.org/repos/%s/latest/x86_64/repodata/" % BRCHNAME,
+    "rawhide": "https://dl.fedoraproject.org/pub/fedora/linux/development/%s/Everything/x86_64/os/repodata/"  # noqa
+    % BRCHNAME,
+}
+KEYWORDS = [
+    "-filelists.sqlite",
+    "-other.sqlite",
+    "-primary.sqlite",
+]
+DTBSLIST = []
+
+
+def databases_presence(brchname):
+    """
+    Return true if the databases are present of the given branch, else false
+    """
+    for indx in KEYWORDS:
+        if not os.path.exists("%smdapi-%s%s" % (LOCATION, brchname, indx)):
+            return False
+    return True
+
+
+def populate_test_databases():
+    """
+    Create a directory for populating the test database directory
+    (That is if it does not exist)
+    """
+
+    if not databases_presence("rawhide") or not databases_presence("koji"):
+        if not os.path.exists("/var/tmp/mdapi-tests/"):
+            os.mkdir("/var/tmp/mdapi-tests/")
+
+        """
+        Create a list of links, download and extract them from the specified source
+        """
+        for kndx in PROBEURL.keys():
+            htmlcont = requests.get(PROBEURL[kndx]).text
+            soupobjc = BeautifulSoup(htmlcont, "html.parser")
+            for indx in soupobjc.find_all("a"):
+                for jndx in KEYWORDS:
+                    if jndx in indx.get("href"):
+                        dtbslink = "%s%s" % (PROBEURL[kndx], indx.get("href"))
+                        arcvloca = "%s%s" % (LOCATION, indx.get("href"))
+                        fileloca = "%s%s" % (
+                            LOCATION,
+                            indx.get("href").replace(
+                                indx.get("href").split("-")[0], "mdapi-%s" % kndx
+                            ),
+                        )
+                        fileloca = fileloca.replace(".%s" % indx.get("href").split(".")[-1], "")
+                        try:
+                            fetch_database(kndx, dtbslink, arcvloca)
+                            extract_database(kndx, arcvloca, fileloca)
+                            os.remove(arcvloca)
+                        except HTTPError as excp:
+                            logrobjc.warning("[%s] Archive could not be found : %s" % (kndx, excp))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -27,7 +27,7 @@ import requests
 from bs4 import BeautifulSoup
 from requests.exceptions import HTTPError
 
-from mdapi.confdata.servlogr import logrobjc
+from mdapi.confdata import servlogr
 from mdapi.database.main import extract_database, fetch_database
 
 """
@@ -92,4 +92,6 @@ def populate_test_databases():
                             extract_database(kndx, arcvloca, fileloca)
                             os.remove(arcvloca)
                         except HTTPError as excp:
-                            logrobjc.warning("[%s] Archive could not be found : %s" % (kndx, excp))
+                            servlogr.logrobjc.warning(
+                                "[%s] Archive could not be found : %s" % (kndx, excp)
+                            )

--- a/tests/test_clim.py
+++ b/tests/test_clim.py
@@ -1,0 +1,38 @@
+"""
+mdapi
+Copyright (C) 2015-2022 Red Hat, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Any Red Hat trademarks that are incorporated in the source
+code or documentation are not subject to the GNU General Public
+License and may only be used or replicated with the express permission
+of Red Hat, Inc.
+"""
+
+from click.testing import CliRunner
+
+from mdapi.main import main
+
+
+def test_cli_application_help_option():
+    rnnrobjc = CliRunner()
+    rsltobjc = rnnrobjc.invoke(main, ["--help"])
+    assert rsltobjc.exit_code == 0
+
+
+def test_cli_application_version_option():
+    rnnrobjc = CliRunner()
+    rsltobjc = rnnrobjc.invoke(main, ["--version"])
+    assert rsltobjc.exit_code == 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,143 @@
+"""
+mdapi
+Copyright (C) 2015-2022 Red Hat, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Any Red Hat trademarks that are incorporated in the source
+code or documentation are not subject to the GNU General Public
+License and may only be used or replicated with the express permission
+of Red Hat, Inc.
+"""
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from mdapi.confdata.standard import DB_FOLDER  # noqa
+from mdapi.main import main
+from mdapi.services.main import buildapp
+from tests import LOCATION, databases_presence, populate_test_databases
+
+
+@pytest.fixture(scope="module")
+def setup_environment():
+    """
+    Collect the SQLite databases from the mirror
+    to have some data to test against
+    """
+    populate_test_databases()
+    assert databases_presence("rawhide") and databases_presence("koji")
+
+
+@pytest.fixture
+async def testing_application(setup_environment, loop, aiohttp_client):
+    global DB_FOLDER
+    DB_FOLDER = LOCATION
+    applobjc = await buildapp()
+    return await aiohttp_client(applobjc)
+
+
+def test_cli_application_help_option():
+    rnnrobjc = CliRunner()
+    rsltobjc = rnnrobjc.invoke(main, ["--help"])
+    assert rsltobjc.exit_code == 0
+
+
+def test_cli_application_version_option():
+    rnnrobjc = CliRunner()
+    rsltobjc = rnnrobjc.invoke(main, ["--version"])
+    assert rsltobjc.exit_code == 0
+
+
+async def test_view_index_page(testing_application):
+    respobjc = await testing_application.get("/")
+    assert respobjc.status == 200
+    botmtext = "2015-2022 - Red Hat, Inc. - GPLv3+ - Sources:"
+    otptrslt = await respobjc.text()
+    assert botmtext in otptrslt
+
+
+async def test_view_branches(testing_application):
+    respobjc = await testing_application.get("/branches")
+    assert respobjc.status == 200
+    otptobjc = await respobjc.text()
+    assert "src_rawhide" in otptobjc
+    assert "rawhide" in otptobjc
+
+
+@pytest.mark.skipif(
+    not databases_presence("rawhide"),
+    reason="Databases for 'rawhide' repositories could not be fetched",
+)
+async def test_view_pkg_rawhide(testing_application):
+    respobjc = await testing_application.get("/rawhide/pkg/kernel")
+    assert respobjc.status == 200
+    json.loads(await respobjc.text())
+
+
+@pytest.mark.skipif(
+    not databases_presence("rawhide"),
+    reason="Databases for 'rawhide' repositories could not be fetched",
+)
+async def test_view_pkg_rawhide_invalid(testing_application):
+    respobjc = await testing_application.get("/rawhide/pkg/invalidpackagename")
+    assert respobjc.status == 404
+    assert "404: Not Found" == await respobjc.text()
+
+
+@pytest.mark.skipif(
+    not databases_presence("rawhide"),
+    reason="Databases for 'rawhide' repositories could not be fetched",
+)
+async def test_view_pkg_srcpkg_rawhide(testing_application):
+    respobjc = await testing_application.get("/rawhide/srcpkg/python-natsort")
+    assert respobjc.status == 200
+    json.loads(await respobjc.text())
+
+
+@pytest.mark.skipif(
+    not databases_presence("rawhide"),
+    reason="Databases for 'rawhide' repositories could not be fetched",
+)
+async def test_view_changelog_rawhide(testing_application):
+    respobjc = await testing_application.get("/rawhide/changelog/kernel")
+    assert respobjc.status == 200
+    json.loads(await respobjc.text())
+
+
+@pytest.mark.skipif(
+    not databases_presence("koji"),
+    reason="Databases for 'koji' repositories could not be fetched",
+)
+@pytest.mark.parametrize(
+    "action, package, status_code",
+    [
+        ("requires", "R", 200),
+        ("provides", "perl(SetupLog)", 400),
+        ("provides", "R", 200),
+        ("obsoletes", "cabal2spec", 200),
+        ("conflicts", "mariadb", 200),
+        ("enhances", "httpd", 200),
+        ("recommends", "flac", 200),
+        ("suggests", "httpd", 200),
+        ("supplements", "(hunspell and langpacks-fr)", 200),
+    ],
+)
+async def test_view_property_koji(testing_application, action, package, status_code):
+    respobjc = await testing_application.get("/koji/%s/%s" % (action, package))
+    assert respobjc.status == status_code
+    if status_code == 200:
+        json.loads(await respobjc.text())

--- a/tests/test_nodb.py
+++ b/tests/test_nodb.py
@@ -1,0 +1,98 @@
+"""
+mdapi
+Copyright (C) 2015-2022 Red Hat, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Any Red Hat trademarks that are incorporated in the source
+code or documentation are not subject to the GNU General Public
+License and may only be used or replicated with the express permission
+of Red Hat, Inc.
+"""
+
+
+import pytest
+
+from mdapi.confdata import standard
+from mdapi.services.main import buildapp
+
+
+@pytest.fixture
+async def testing_application_nodb(event_loop, aiohttp_client):
+    standard.DB_FOLDER = "."
+    applobjc = await buildapp()
+    return await aiohttp_client(applobjc)
+
+
+async def test_view_index_page(testing_application_nodb):
+    respobjc = await testing_application_nodb.get("/")
+    assert respobjc.status == 200
+    botmtext = "2015-2022 - Red Hat, Inc. - GPLv3+ - Sources:"
+    otptrslt = await respobjc.text()
+    assert botmtext in otptrslt
+
+
+async def test_view_branches(testing_application_nodb):
+    respobjc = await testing_application_nodb.get("/branches")
+    assert respobjc.status == 200
+    assert "[]" == await respobjc.text()
+
+
+async def test_view_pkg_rawhide(testing_application_nodb):
+    respobjc = await testing_application_nodb.get("/rawhide/pkg/kernel")
+    assert respobjc.status == 400
+    assert "400: Bad Request" == await respobjc.text()
+
+
+async def test_view_pkg_rawhide_invalid(testing_application_nodb):
+    respobjc = await testing_application_nodb.get("/rawhide/pkg/invalidpackagename")
+    assert respobjc.status == 400
+    assert "400: Bad Request" == await respobjc.text()
+
+
+async def test_view_srcpkg_rawhide(testing_application_nodb):
+    respobjc = await testing_application_nodb.get("/rawhide/srcpkg/python-natsort")
+    assert respobjc.status == 400
+    assert "400: Bad Request" == await respobjc.text()
+
+
+async def test_view_filelist_rawhide(testing_application_nodb):
+    respobjc = await testing_application_nodb.get("/rawhide/files/kernel-core")
+    assert respobjc.status == 400
+    assert "400: Bad Request" == await respobjc.text()
+
+
+async def test_view_changelog_rawhide(testing_application_nodb):
+    respobjc = await testing_application_nodb.get("/rawhide/changelog/kernel")
+    assert respobjc.status == 400
+    assert "400: Bad Request" == await respobjc.text()
+
+
+@pytest.mark.parametrize(
+    "action",
+    [
+        "requires",
+        "provides",
+        "obsoletes",
+        "conflicts",
+        "enhances",
+        "recommends",
+        "suggests",
+        "supplements",
+    ],
+)
+async def test_view_property_koji(testing_application_nodb, action):
+    respobjc = await testing_application_nodb.get("/koji/%s/R" % (action))
+    assert respobjc.status == 400
+    assert "400: Bad Request" == await respobjc.text()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,44 @@
+[tox]
+minversion = 3.8.0
+envlist = py{38,39,310},black,flake8,isort
+isolated_build = true
+skip_missing_interpreters = true
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+skip_install = true
+sitepackages = false
+whitelist_externals = poetry
+commands =
+    pip3 install --upgrade poetry
+    poetry install
+    mdapi --version
+    pytest -vvv tests/
+
+[testenv:black]
+deps =
+    black >= 22.8.0
+commands =
+    black --diff mdapi/ tests/
+
+[testenv:flake8]
+deps =
+    flake8 < 4
+commands =
+    flake8 mdapi/ tests/
+
+[testenv:isort]
+deps =
+    isort >= 5.10.1
+commands =
+    isort --diff mdapi/ tests/
+
+[black]
+line-length = 100
+
+[flake8]
+max-line-length = 100
+
+[isort]
+profile = black


### PR DESCRIPTION
Fixes #5

Does
1. Flake8 checks (https://flake8.pycqa.org/en/latest/)
2. Isort checks (https://pycqa.github.io/isort/)
3. Black checks (https://black.readthedocs.io/en/stable/)
4. API tests for when the database is present (https://pagure.io/mdapi/blob/master/f/tests/test_mdapi_data.py)
5. API tests for when the database is absent (https://pagure.io/mdapi/blob/master/f/tests/test_mdapi_empty.py)
6. Tests for the newly introduced CLI interface

I also reduced the setup phase of the test, which previously used to fetch the databases for all the branches and take a very long time in doing so before the actual tests began. This one fetches just `rawhide` and `koji` branches which are used in the API testing and thus, reduces the testing duration.